### PR TITLE
DW Attribute Refactor (#128)

### DIFF
--- a/Source/GMCAbilitySystem/GMCAbilitySystem.Build.cs
+++ b/Source/GMCAbilitySystem/GMCAbilitySystem.Build.cs
@@ -35,6 +35,13 @@ public class GMCAbilitySystem : ModuleRules
 			}
 			);
 		
+		if (Target.Configuration != UnrealTargetConfiguration.Shipping)
+		{
+			PrivateDependencyModuleNames.AddRange(new string[] {
+				"AutomationController",
+				"AutomationWorker"
+			});
+		}
 		
 		DynamicallyLoadedModuleNames.AddRange(
 			new string[]

--- a/Source/GMCAbilitySystem/Private/Ability/Tasks/GMCAbilityTaskBase.cpp
+++ b/Source/GMCAbilitySystem/Private/Ability/Tasks/GMCAbilityTaskBase.cpp
@@ -50,6 +50,7 @@ void UGMCAbilityTaskBase::AncillaryTick(float DeltaTime){
 	else if (LastHeartbeatReceivedTime + HeartbeatMaxInterval < AbilitySystemComponent->ActionTimer)
 	{
 		UE_LOG(LogGMCReplication, Error, TEXT("Server Task Heartbeat Timeout, Cancelling Ability: %s"), *Ability->GetName());
+		AbilitySystemComponent->OnTaskTimeout.Broadcast(Ability->AbilityTag);
 		Ability->EndAbility();
 		EndTask();
 	}

--- a/Source/GMCAbilitySystem/Private/Ability/Tasks/WaitForInputKeyPress.cpp
+++ b/Source/GMCAbilitySystem/Private/Ability/Tasks/WaitForInputKeyPress.cpp
@@ -3,6 +3,7 @@
 #include "EnhancedInputComponent.h"
 #include "EnhancedInputSubsystems.h"
 #include "Components/GMCAbilityComponent.h"
+#include "Kismet/KismetSystemLibrary.h"
 
 UGMCAbilityTask_WaitForInputKeyPress* UGMCAbilityTask_WaitForInputKeyPress::WaitForKeyPress(UGMCAbility* OwningAbility, bool bCheckForPressDuringActivation, float MaxDuration)
 {
@@ -32,6 +33,8 @@ void UGMCAbilityTask_WaitForInputKeyPress::Activate()
 		const FEnhancedInputActionEventBinding& Binding = EnhancedInputComponent->BindAction(
 			Ability->AbilityInputAction, ETriggerEvent::Started, this,
 			&UGMCAbilityTask_WaitForInputKeyPress::OnKeyPressed);
+
+		
 	
 		InputBindingHandle = Binding.GetHandle();
 
@@ -43,7 +46,8 @@ void UGMCAbilityTask_WaitForInputKeyPress::Activate()
 			if (UEnhancedInputLocalPlayerSubsystem* InputSubSystem = ULocalPlayer::GetSubsystem<UEnhancedInputLocalPlayerSubsystem>(PC->GetLocalPlayer())) {
 				ActionValue = InputSubSystem->GetPlayerInput() ? InputSubSystem->GetPlayerInput()->GetActionValue(Ability->AbilityInputAction) : FInputActionValue();
 			}
-			if (ActionValue.GetMagnitude() == 1)
+			
+			if (!ActionValue.GetMagnitude())
 			{
 				InputBindingHandle = -1;
 				ClientProgressTask();
@@ -73,6 +77,7 @@ void UGMCAbilityTask_WaitForInputKeyPress::AncillaryTick(float DeltaTime)
 
 void UGMCAbilityTask_WaitForInputKeyPress::OnKeyPressed(const FInputActionValue& InputActionValue)
 {
+	
 	// Unbind from the input component so we don't fire multiple times.
 	if (InputComponent)
 	{

--- a/Source/GMCAbilitySystem/Private/Attributes/GMCAttributeModifier.cpp
+++ b/Source/GMCAbilitySystem/Private/Attributes/GMCAttributeModifier.cpp
@@ -1,0 +1,129 @@
+#include "Attributes/GMCAttributeModifier.h"
+
+#include "GMCAbilityComponent.h"
+
+float FGMCAttributeModifier::GetValue() const
+{
+	// Get The Value Type
+	switch (ValueType)
+	{
+	case EGMCAttributeModifierType::AMT_Value:
+		return ModifierValue;
+	case EGMCAttributeModifierType::AMT_Attribute:
+		{
+			if (SourceAbilityEffect.IsValid() && SourceAbilityEffect->GetOwnerAbilityComponent())
+			{
+				return SourceAbilityEffect->GetOwnerAbilityComponent()->GetAttributeValueByTag(ValueAsAttribute);
+			}
+			UE_LOG(LogGMCAbilitySystem, Error, TEXT("SourceAbilityEffect is null in FAttribute::AddModifier"));
+			return 0.f;
+		}
+	case EGMCAttributeModifierType::AMT_Custom:
+		if (CustomModifierClass && SourceAbilityEffect.IsValid() && SourceAbilityEffect->GetOwnerAbilityComponent())
+		{
+			if (UGMCAttributeModifierCustom_Base* CustomModifier = CustomModifierClass->GetDefaultObject<UGMCAttributeModifierCustom_Base>())
+			{
+				return CustomModifier->Calculate(SourceAbilityEffect.Get(), SourceAbilityEffect->GetOwnerAbilityComponent()->GetAttributeByTag(AttributeTag));
+			}
+			UE_LOG(LogGMCAbilitySystem, Error, TEXT("Custom Modifier Class is null in FAttribute::AddModifier"));
+		}
+		else
+		{
+			UE_LOG(LogGMCAbilitySystem, Error, TEXT("CustomModifierClass is null or SourceAbilityEffect/SourceAbilitySystemComponent is invalid in FAttribute::AddModifier"));
+		}
+		break;
+	}
+
+	checkNoEntry()
+	return 0.f;
+}
+
+float FGMCAttributeModifier::CalculateModifierValue(const FAttribute& Attribute) const
+{
+		float TargetValue = GetValue();
+	
+	// First set Percentage values to a fraction
+	switch (Op)
+	{
+		case EModifierType::AddPercentageAttribute:
+		case EModifierType::AddPercentageInitialValue:
+		case EModifierType::AddPercentageAttributeSum:
+		case EModifierType::AddPercentageMissing:
+		case EModifierType::AddPercentageMinClamp:
+		case EModifierType::AddPercentageMaxClamp:
+		case EModifierType::AddPercentageOfAttributeRawValue:
+			TargetValue /= 100.f;
+		break;
+	}
+	
+	switch (Op)
+	{
+		case EModifierType::Add:
+			return TargetValue * DeltaTime;
+		case EModifierType::AddPercentageInitialValue:
+			return Attribute.InitialValue * TargetValue * DeltaTime;
+		case EModifierType::AddPercentageAttribute:
+			return SourceAbilityEffect->GetOwnerAbilityComponent()->GetAttributeValueByTag(ValueAsAttribute) * TargetValue * DeltaTime;
+		case EModifierType::AddPercentageMaxClamp:
+			{
+				const float MaxValue = Attribute.Clamp.MaxAttributeTag.IsValid() ? SourceAbilityEffect->GetOwnerAbilityComponent()->GetAttributeValueByTag(Attribute.Clamp.MaxAttributeTag) : Attribute.Clamp.Max;
+				return MaxValue * TargetValue * DeltaTime;
+			}
+		case EModifierType::AddPercentageMinClamp:
+			{
+				const float MinValue = Attribute.Clamp.MinAttributeTag.IsValid() ? SourceAbilityEffect->GetOwnerAbilityComponent()->GetAttributeValueByTag(Attribute.Clamp.MinAttributeTag) : Attribute.Clamp.Min;
+				return MinValue * TargetValue * DeltaTime;
+			}
+		case EModifierType::AddPercentageAttributeSum:
+			{
+				float Sum = 0.f;
+				for (auto& AttTag : Attributes)
+				{
+					Sum += SourceAbilityEffect->GetOwnerAbilityComponent()->GetAttributeValueByTag(AttTag);
+				}
+				return TargetValue * Sum * DeltaTime;
+			}
+		case EModifierType::AddScaledBetween:
+			{
+				const float XBound = XAsAttribute ? SourceAbilityEffect->GetOwnerAbilityComponent()->GetAttributeValueByTag(XAttribute) : X;
+				const float YBound = YAsAttribute ? SourceAbilityEffect->GetOwnerAbilityComponent()->GetAttributeValueByTag(YAttribute) : Y;
+				return FMath::Clamp(FMath::Lerp(XBound, YBound, TargetValue), X, Y) * DeltaTime;
+			}
+		case EModifierType::AddClampedBetween:
+			{
+				const float XBound = XAsAttribute ? SourceAbilityEffect->GetOwnerAbilityComponent()->GetAttributeValueByTag(XAttribute) : X;
+				const float YBound = YAsAttribute ? SourceAbilityEffect->GetOwnerAbilityComponent()->GetAttributeValueByTag(YAttribute) : Y;
+				return FMath::Clamp(TargetValue, XBound, YBound) * DeltaTime;
+			}
+		case EModifierType::AddPercentageMissing:
+			{
+				const float MissingValue =  Attribute.InitialValue - Attribute.Value;
+				return TargetValue * MissingValue * DeltaTime;
+			}
+		case EModifierType::AddPercentageOfAttributeRawValue:
+			{
+				const float RawValue = SourceAbilityEffect->GetOwnerAbilityComponent()->GetAttributeRawValue(Attribute.Tag);
+				return TargetValue * RawValue * DeltaTime;
+			}
+	}
+
+	UE_LOG(LogGMCAbilitySystem, Error, TEXT("Unknown Modifier Type in FAttribute::AddModifier for Attribute %s, operator %d"), *Attribute.Tag.ToString(), static_cast<int32>(Op));
+	checkNoEntry();
+	return 0.f;
+}
+
+void FGMCAttributeModifier::InitModifier(UGMCAbilityEffect* Effect, double InActionTimer, int InApplicationIdx, bool bInRegisterInHistory, float InDeltaTime)
+{
+	if (!Effect)
+	{
+		UE_LOG(LogGMCAbilitySystem, Error, TEXT("Effect or AbilitySystemComponent is null in FGMCAttributeModifier::InitModifier"));
+		return;
+	}
+
+	SourceAbilityEffect = Effect;
+	bRegisterInHistory = bInRegisterInHistory;
+	DeltaTime = InDeltaTime;
+	ApplicationIndex = InApplicationIdx;
+	ActionTimer = InActionTimer;
+	
+}

--- a/Source/GMCAbilitySystem/Private/Attributes/GMCAttributeModifierCustom_Base.cpp
+++ b/Source/GMCAbilitySystem/Private/Attributes/GMCAttributeModifierCustom_Base.cpp
@@ -1,0 +1,32 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "GMCAttributeModifierCustom_Base.h"
+#include "GMCAbilitySystem/Public/Attributes/GMCAttributes.h"
+
+float UGMCAttributeModifierCustom_Base::Calculate(UGMCAbilityEffect* SourceEffect, const FAttribute* Attribute)
+{
+	if (!CheckValidity(SourceEffect, Attribute))	
+	{
+		return 0.f; // Invalid state, return 0
+	}
+			
+	return K2_Calculate(SourceEffect, Attribute->Tag);
+}
+
+bool UGMCAttributeModifierCustom_Base::CheckValidity(const UGMCAbilityEffect* SourceEffect, const FAttribute* Attribute) const
+{
+	if (SourceEffect == nullptr)
+	{
+		UE_LOG(LogGMCAbilitySystem, Error, TEXT("SourceEffect is null in UGMCAttributeModifierCustom_Base::CheckValidity"));
+		return false;
+	}
+
+	if (Attribute == nullptr)
+	{
+		UE_LOG(LogGMCAbilitySystem, Error, TEXT("Attribute is null in UGMCAttributeModifierCustom_Base::CheckValidity"));
+		return false;
+	}
+
+	return true;
+}

--- a/Source/GMCAbilitySystem/Private/Attributes/GMCAttributes.cpp
+++ b/Source/GMCAbilitySystem/Private/Attributes/GMCAttributes.cpp
@@ -1,0 +1,97 @@
+#include "Attributes/GMCAttributes.h"
+
+#include "GMCAbilityComponent.h"
+
+void FAttribute::AddModifier(const FGMCAttributeModifier& PendingModifier) const
+{
+	
+	const float ModifierValue = PendingModifier.CalculateModifierValue(*this);
+	
+	if (PendingModifier.bRegisterInHistory)
+	{
+		ValueTemporalModifiers.Add(FAttributeTemporaryModifier(PendingModifier.ApplicationIndex, ModifierValue, PendingModifier.ActionTimer, PendingModifier.SourceAbilityEffect));
+	}
+	else
+	{
+		RawValue = Clamp.ClampValue(RawValue + ModifierValue);
+	}
+
+	bIsDirty = true;
+}
+
+void FAttribute::CalculateValue() const
+{
+
+	Value = Clamp.ClampValue(RawValue);
+	
+	for (auto& Mod : ValueTemporalModifiers)
+	{
+		if (Mod.InstigatorEffect.IsValid())
+		{
+			Value += Mod.Value;
+			Value = Clamp.ClampValue(Value);
+		}
+		else
+		{
+			UE_LOG(LogGMCAbilitySystem, Error, TEXT("Orphelin Attribute Modifier found in FAttribute::CalculateValue"));
+			checkNoEntry();
+		}
+	}
+
+	bIsDirty = false;
+}
+
+void FAttribute::RemoveTemporalModifier(int ApplicationIndex, const UGMCAbilityEffect* InstigatorEffect) const
+{
+	for (int i = ValueTemporalModifiers.Num() - 1; i >= 0; i--)
+	{
+		if (ValueTemporalModifiers[i].ApplicationIndex == ApplicationIndex && ValueTemporalModifiers[i].InstigatorEffect == InstigatorEffect)
+		{
+			ValueTemporalModifiers.RemoveAt(i);
+			bIsDirty = true;
+		}
+	}
+}
+
+void FAttribute::PurgeTemporalModifier(double CurrentActionTimer)
+{
+
+	if (!bIsGMCBound)
+	{
+		UE_LOG(LogGMCAbilitySystem, Error, TEXT("PurgeTemporalModifier called on an unbound attribute %s"), *Tag.ToString());
+		checkNoEntry();
+		return;
+	}
+	
+	bool bMustReprocessModifiers = false;
+	for (int i = ValueTemporalModifiers.Num() - 1; i >= 0; i--)
+	{
+		if (ValueTemporalModifiers[i].ActionTimer > CurrentActionTimer)
+		{
+			ValueTemporalModifiers.RemoveAt(i);
+			bMustReprocessModifiers = true;
+		}
+	}
+
+	if (bMustReprocessModifiers)
+	{
+		bIsDirty = true;
+	}
+}
+
+FString FAttribute::ToString() const
+{
+	if (bIsGMCBound)
+	{
+		return FString::Printf(TEXT("%s : %0.3f Bound[n%i/%0.2fmb]"), *Tag.ToString(), Value, ValueTemporalModifiers.Num(), ValueTemporalModifiers.GetAllocatedSize() / 1048576.0f);
+	}
+	else
+	{
+		return FString::Printf(TEXT("%s : %0.3f"), *Tag.ToString(), Value);
+	}
+}
+
+bool FAttribute::operator<(const FAttribute& Other) const
+{
+	return Tag.ToString() < Other.Tag.ToString();
+}

--- a/Source/GMCAbilitySystem/Private/Attributes/PreDefinedCustomCalculator/GMCModifierCustom_Exponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Attributes/PreDefinedCustomCalculator/GMCModifierCustom_Exponent.cpp
@@ -1,0 +1,48 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "GMCModifierCustom_Exponent.h"
+
+#include "GMCAttributes.h"
+
+float UGMCModifierCustom_Exponent::Calculate(UGMCAbilityEffect* SourceEffect, const FAttribute* Attribute)
+{
+
+	if (!CheckValidity(SourceEffect, Attribute))	
+	{
+		return 0.f; // Invalid state, return 0
+	}
+	
+	switch (ExponentType) {
+		case EGMCMC_ExponentType::Mapping:
+			{
+				const float x = Attribute->Value * 3;
+				const float rawExp = FMath::Exp(x);
+				constexpr float minExp = 1.f;
+				constexpr float MaxExp = 0x1.42096ff2afc4p+4; // exp(3)
+		
+				return Min + ((rawExp - minExp) / (MaxExp - minExp)) * (Max - Min);
+				break;
+			}
+		case EGMCMC_ExponentType::Easing:
+			{
+				const float easedT = Attribute->Value == 0 ? 0 : FMath::Pow(2, 10 *(Attribute->Value - 1.f));
+				return Min + easedT * (Max - Min);
+				break;
+			}
+		case EGMCMC_ExponentType::CustomPower:
+			{
+				const float poweredT = FMath::Pow(Attribute->Value, k);
+				return Min + poweredT * (Max - Min);
+				break;
+			}
+		case EGMCMC_ExponentType::Saturated:
+			{
+				const float expValue = 1 - FMath::Exp(-k * Attribute->Value);
+				return Min + expValue * (Max - Min);
+				break;
+			}
+	}
+
+	return Attribute->Value; // Fallback, should not happen
+}

--- a/Source/GMCAbilitySystem/Private/Attributes/PreDefinedCustomCalculator/GMCModifierCustom_Exponent.h
+++ b/Source/GMCAbilitySystem/Private/Attributes/PreDefinedCustomCalculator/GMCModifierCustom_Exponent.h
@@ -1,0 +1,41 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GMCAttributeModifierCustom_Base.h"
+#include "GMCModifierCustom_Exponent.generated.h"
+
+UENUM()
+enum class EGMCMC_ExponentType
+{
+	Mapping UMETA(DisplayName = "Mapping", ToolTip="Classique Exponent scale"),
+	Easing UMETA(DisplayName = "Easing", ToolTip="Easing scale"),
+	CustomPower UMETA(DisplayName = "Custom Power", ToolTip="Custom Power"),
+	Saturated UMETA(DisplayName = "Saturated", ToolTip="Saturated scale")
+};
+
+/**
+ * 
+ */
+UCLASS()
+class GMCABILITYSYSTEM_API UGMCModifierCustom_Exponent : public UGMCAttributeModifierCustom_Base
+{
+	GENERATED_BODY()
+
+	public:
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = Exponent)
+	EGMCMC_ExponentType ExponentType;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = Exponent)
+	float Min = 0.0f;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = Exponent)
+	float Max = 0.f;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = Exponent, meta=(EditCondition = "ExponentType == EGMCMC_ExponentType::Saturated || ExponentType == EGMCMC_ExponentType::CustomPower", EditConditionHides));
+	float k = 0.f;
+
+	virtual float Calculate(UGMCAbilityEffect* SourceEffect, const FAttribute* Attribute) override;
+};

--- a/Source/GMCAbilitySystem/Private/Debug/GameplayDebuggerCategory_GMCAbilitySystem.cpp
+++ b/Source/GMCAbilitySystem/Private/Debug/GameplayDebuggerCategory_GMCAbilitySystem.cpp
@@ -23,11 +23,18 @@ void FGameplayDebuggerCategory_GMCAbilitySystem::CollectData(APlayerController* 
 		{
 			AbilityComponent->GMCMovementComponent->SV_SwapServerState();
 			DataPack.GrantedAbilities = AbilityComponent->GetGrantedAbilities().ToStringSimple();
+			DataPack.NBGrantedAbilities = AbilityComponent->GetGrantedAbilities().Num();
 			DataPack.ActiveTags = AbilityComponent->GetActiveTags().ToStringSimple();
+			DataPack.NBActiveTags = AbilityComponent->GetActiveTags().Num();
 			DataPack.Attributes = AbilityComponent->GetAllAttributesString();
+			DataPack.NBAttributes = AbilityComponent->GetAllAttributes().Num();
 			DataPack.ActiveEffects = AbilityComponent->GetActiveEffectsString();
+			DataPack.NBActiveEffects = AbilityComponent->GetActiveEffects().Num();
 			DataPack.ActiveEffectData = AbilityComponent->GetActiveEffectsDataString();
+			DataPack.NBActiveEffectData = AbilityComponent->ActiveEffectsData.Num();
 			DataPack.ActiveAbilities = AbilityComponent->GetActiveAbilitiesString();
+			DataPack.NBActiveAbilities = AbilityComponent->GetActiveAbilities().Num();
+			
 			AbilityComponent->GMCMovementComponent->SV_SwapServerState();
 		}
 	}
@@ -44,20 +51,38 @@ void FGameplayDebuggerCategory_GMCAbilitySystem::DrawData(APlayerController* Own
 	{
 		CanvasContext.Printf(TEXT("{yellow}Actor name: {white}%s"), *DataPack.ActorName);
 
+		constexpr int MaxCharDisplayAbilities = 100;
 		// Abilities
-		CanvasContext.Printf(TEXT("{blue}[server] {yellow}Granted Abilities: {white}%s"), *DataPack.GrantedAbilities);
+		CanvasContext.Printf(TEXT("{blue}[server] {yellow}Granted Abilities (%d): {white}%s%s"), DataPack.NBGrantedAbilities, *DataPack.GrantedAbilities.Left(MaxCharDisplayAbilities), DataPack.GrantedAbilities.Len() > MaxCharDisplayAbilities ? TEXT("...") : TEXT(""));
 		// Show client-side data
 		if (AbilityComponent)
 		{
-			CanvasContext.Printf(TEXT("{green}[client] {yellow}Granted Abilities: {white}%s"), *AbilityComponent->GetGrantedAbilities().ToStringSimple());
+			if (DataPack.NBGrantedAbilities != AbilityComponent->GetGrantedAbilities().Num())
+			{
+				CanvasContext.Printf(
+					TEXT("{green}[client] {yellow}Granted Abilities (%d): {red} [INCOHERENCY] {white}%s%s"),
+					AbilityComponent->GetGrantedAbilities().Num(),
+					*AbilityComponent->GetGrantedAbilities().ToStringSimple().Left(MaxCharDisplayAbilities),
+					AbilityComponent->GetGrantedAbilities().ToStringSimple().Len() > MaxCharDisplayAbilities ? TEXT("...") : TEXT(""));
+			}
+			else
+			{
+				CanvasContext.Printf(
+					TEXT("{green}[client] {yellow}Granted Abilities (%d): {white}%s%s"), AbilityComponent->GetGrantedAbilities().Num(),
+					*AbilityComponent->GetGrantedAbilities().ToStringSimple().Left(MaxCharDisplayAbilities),
+					AbilityComponent->GetGrantedAbilities().ToStringSimple().Len() > MaxCharDisplayAbilities ? TEXT("...") : TEXT(""));
+			}
 		}
 
 		// Active Abilities
-		CanvasContext.Printf(TEXT("{blue}[server] {yellow}Active Abilities: {white}%s"), *DataPack.ActiveAbilities);
+		CanvasContext.Printf(TEXT("\n{blue}[server] {yellow}Active Abilities: {white}%s"), *DataPack.ActiveAbilities);
 		// Show client-side data
 		if (AbilityComponent)
 		{
-			CanvasContext.Printf(TEXT("{green}[client] {yellow}Active Abilities: {white}%s"), *AbilityComponent->GetActiveAbilitiesString());
+			if (DataPack.NBActiveAbilities != AbilityComponent->GetActiveAbilities().Num())
+				CanvasContext.Printf(TEXT("{green}[client] {yellow}Active Abilities: {red} [INCOHERENCY] {white}%s"), *AbilityComponent->GetActiveAbilitiesString());
+			else
+				CanvasContext.Printf(TEXT("{green}[client] {yellow}Active Abilities: {white}%s"), *AbilityComponent->GetActiveAbilitiesString());
 		}
 
 		// Tags
@@ -65,7 +90,10 @@ void FGameplayDebuggerCategory_GMCAbilitySystem::DrawData(APlayerController* Own
 		// Show client-side data
 		if (AbilityComponent)
 		{
-			CanvasContext.Printf(TEXT("{green}[client] {yellow}Active Tags: {white}%s"), *AbilityComponent->GetActiveTags().ToStringSimple());
+			if (DataPack.NBActiveTags != AbilityComponent->GetActiveTags().Num())
+				CanvasContext.Printf(TEXT("{green}[client] {yellow}Active Tags: {red} [INCOHERENCY] {white}%s"), *AbilityComponent->GetActiveTags().ToStringSimple());
+			else
+				CanvasContext.Printf(TEXT("{green}[client] {yellow}Active Tags: {white}%s"), *AbilityComponent->GetActiveTags().ToStringSimple());
 		}
 
 		// Attributes
@@ -73,7 +101,10 @@ void FGameplayDebuggerCategory_GMCAbilitySystem::DrawData(APlayerController* Own
 		// Show client-side data
 		if (AbilityComponent)
 		{
-			CanvasContext.Printf(TEXT("{green}[client] {yellow}Attributes: {white}%s"), *AbilityComponent->GetAllAttributesString());
+			if (DataPack.NBAttributes != AbilityComponent->GetAllAttributes().Num())
+				CanvasContext.Printf(TEXT("{green}[client] {yellow}Attributes: {red} [INCOHERENCY] {white}%s"), *AbilityComponent->GetAllAttributesString());
+			else
+				CanvasContext.Printf(TEXT("{green}[client] {yellow}Attributes: {white}%s"), *AbilityComponent->GetAllAttributesString());
 		}
 
 		// Active Effects
@@ -81,7 +112,10 @@ void FGameplayDebuggerCategory_GMCAbilitySystem::DrawData(APlayerController* Own
 		// Show client-side data
 		if (AbilityComponent)
 		{
-			CanvasContext.Printf(TEXT("{green}[client] {yellow}Active Effects: {white}%s"), *AbilityComponent->GetActiveEffectsString());
+			if (DataPack.NBActiveEffects != AbilityComponent->GetActiveEffects().Num())
+				CanvasContext.Printf(TEXT("{green}[client] {yellow}Active Effects: {red} [INCOHERENCY] {white}%s"), *AbilityComponent->GetActiveEffectsString());
+			else
+				CanvasContext.Printf(TEXT("{green}[client] {yellow}Active Effects: {white}%s"), *AbilityComponent->GetActiveEffectsString());
 		}
 
 		// Active Effects Data
@@ -89,6 +123,9 @@ void FGameplayDebuggerCategory_GMCAbilitySystem::DrawData(APlayerController* Own
 		// Show client-side data
 		if (AbilityComponent)
 		{
+			if (DataPack.NBActiveEffectData != AbilityComponent->ActiveEffectsData.Num())
+				CanvasContext.Printf(TEXT("{green}[client] {yellow}Active Effects Data: {red} [INCOHERENCY] {white}%s"), *AbilityComponent->GetActiveEffectsDataString());
+			else
 			CanvasContext.Printf(TEXT("{green}[client] {yellow}Active Effects Data: {white}%s"), *AbilityComponent->GetActiveEffectsDataString());
 		}
 		
@@ -109,6 +146,12 @@ void FGameplayDebuggerCategory_GMCAbilitySystem::FRepData::Serialize(FArchive& A
 	Ar << ActiveEffects;
 	Ar << ActiveEffectData;
 	Ar << ActiveAbilities;
+	Ar << NBGrantedAbilities;
+	Ar << NBActiveTags;
+	Ar << NBAttributes;
+	Ar << NBActiveEffects;
+	Ar << NBActiveEffectData;
+	Ar << NBActiveAbilities;
 }
 
 #endif

--- a/Source/GMCAbilitySystem/Public/Ability/GMCAbilityMapData.h
+++ b/Source/GMCAbilitySystem/Public/Ability/GMCAbilityMapData.h
@@ -33,7 +33,7 @@ UCLASS()
 class GMCABILITYSYSTEM_API UGMCAbilityMapData : public UPrimaryDataAsset{
 	GENERATED_BODY()
 
-	UPROPERTY(EditDefaultsOnly, Category = "GMCAbilitySystem")
+	UPROPERTY(EditDefaultsOnly, Category = "GMCAbilitySystem", meta=(TitleProperty="{InputTag}"))
 	TArray<FAbilityMapData> AbilityMapData;
 
 public:

--- a/Source/GMCAbilitySystem/Public/Ability/Tasks/GMCAbilityTaskBase.h
+++ b/Source/GMCAbilitySystem/Public/Ability/Tasks/GMCAbilityTaskBase.h
@@ -7,6 +7,8 @@
 class UGMC_AbilitySystemComponent;
 class UGameplayTasksComponent;
 
+
+
 UCLASS(Abstract, BlueprintType, meta = (ExposedAsyncProxy=AsyncTask), config = Game)
 class GMCABILITYSYSTEM_API UGMCAbilityTaskBase : public UGameplayTask
 {
@@ -66,7 +68,6 @@ public:
 	
 	virtual void Heartbeat();
 
-
 protected:
 	bool bTaskCompleted;
 
@@ -78,13 +79,14 @@ protected:
 
 private:
 	// How often client sends heartbeats to server
-	float HeartbeatInterval = .1f;
+	float HeartbeatInterval = .2f;
 
 	// Max time between heartbeats before server cancels task
-	float HeartbeatMaxInterval =.3f;
+	// Aherys: previous value was 0.3f it's maybe a bit too low for harsh network conditions
+	float HeartbeatMaxInterval = 3.f;
 	
-	float ClientLastHeartbeatSentTime;
-	float LastHeartbeatReceivedTime;
+	float ClientLastHeartbeatSentTime = 0.f;
+	float LastHeartbeatReceivedTime = 0.f;
 
 
 };

--- a/Source/GMCAbilitySystem/Public/Attributes/FAttributeUnitTest.cpp
+++ b/Source/GMCAbilitySystem/Public/Attributes/FAttributeUnitTest.cpp
@@ -1,0 +1,7 @@
+﻿// ReSharper disable CppExpressionWithoutSideEffects
+#include "GMCAttributeModifier.h"
+#include "GMCAttributes.h"
+#include "Misc/AutomationTest.h"
+
+//IMPLEMENT_SIMPLE_AUTOMATION_TEST(FAttributeNewOperatorsTest, "UE5.Marketplace.DeepWorlds_GMCAbilitySystem.Source.GMCAbilitySystem.Public.Attributes.NewOperatorsTest", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+

--- a/Source/GMCAbilitySystem/Public/Attributes/GMCAttributeModifier.h
+++ b/Source/GMCAbilitySystem/Public/Attributes/GMCAttributeModifier.h
@@ -1,36 +1,130 @@
 ﻿#pragma once
 #include "GameplayTags.h"
+#include "GMCAttributeModifierCustom_Base.h"
 #include "GMCAttributeModifier.generated.h"
+
+
+class UGMCAbilityEffect;
+class UGMC_AbilitySystemComponent;
 
 UENUM(BlueprintType)
 enum class EModifierType : uint8
 {
-	// Adds to value
-	Add,
-	// Adds to value multiplier. Base Multiplier is 1. A modifier value of 1 will double the value.
-	Multiply,
-	// Adds to value divisor. Base Divisor is 1. A modifier value of 1 will halve the value.
-	Divide     
+	Add UMETA(DisplayName = "+ [Add]"),
+	// Add To Attribute a Percentage of the Base Value
+	AddPercentageInitialValue UMETA(DisplayName = "% [Add Percentage Of Initial Value]"),
+	// Add to Attribute the Percentage of an selected Attribute (Value is the Percentage, Attribute as Value is the Attribute to use)
+	AddPercentageAttribute UMETA(DisplayName = "% [Add Percentage Of Attribute]"),
+	// Add to Attribute the Percentage of the Max Clamp Value
+	AddPercentageMaxClamp UMETA(DisplayName = "% [Add Percentage Of Max Clamp]"),
+	// Add to Attribute the Percentage of the Min Clamp Value
+	AddPercentageMinClamp UMETA(DisplayName = "% [Add Percentage Of Min Clamp]"),
+	// Add to Attribute the Percentage of the sum of selecteds Attributes (+20% of the Intelligence + Strength)
+	AddPercentageAttributeSum UMETA(DisplayName = "% [Add Percentage Of Attribute Sum]"),
+	// Add to Attribute a Value Scaled between X and Y depending of Value
+	AddScaledBetween UMETA(DisplayName = "X-y [Scaled Between]"),
+	// Add to Attribute a value, but this is Clamped between X and Y
+	AddClampedBetween UMETA(DisplayName = "+ [Add Clamped]"),
+	// Add to Attribute the Percentage of the Missing Value compare to the Base Value
+	AddPercentageMissing UMETA(DisplayName = "% [Add Percentage Of Missing Value]"),
+	// Add to Attribute the Percentage of an Attribute Raw Value (Raw Value is the attribute value without any temporal modifiers)
+	AddPercentageOfAttributeRawValue UMETA(DisplayName = "% [Add Percentage Of Attribute Raw Value"),
+};
+
+UENUM(BlueprintType)
+enum class EGMCAttributeModifierType : uint8
+{
+	AMT_Value UMETA(DisplayName = "Value", ToolTip = "Raw Value"),
+	AMT_Attribute UMETA(DisplayName = "Attribute", ToolTip = "Attribute that will be used to calculate the value"),
+	AMT_Custom UMETA(DisplayName = "Custom", ToolTip = "Custom modifier class that will be used to calculate the value"),
 };
 
 USTRUCT(BlueprintType)
 struct FGMCAttributeModifier
 {
 	GENERATED_BODY()
+
+	public:
+
+		// Return the value (Auto apply Custom Modifier if set, or return target attribute, or raw value)
+		float GetValue() const;
+
+		// Return the value to apply to an attribute on calculation.
+		float CalculateModifierValue(const FAttribute& Attribute) const;
+
+		// If isn't ticking, set DeltaTime to 1.f !
+		void InitModifier(UGMCAbilityEffect* Effect, double InActionTimer, int InApplicationIdx, bool bInRegisterInHistory = false, float
+		                  InDeltaTime = 1.f);
 		
-	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category="Attribute", meta = (Categories="Attribute"))
-	FGameplayTag AttributeTag;
+		UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category="Attribute", meta = (Categories="Attribute"))
+		FGameplayTag AttributeTag;
 
-	// Value to modify the attribute by
-	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem")
-	float Value{0};
+		UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category="Attribute", meta=(DisplayAfter = "AttributeTag"))
+		EGMCAttributeModifierType ValueType {EGMCAttributeModifierType::AMT_Value};
 
-	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem")
-	EModifierType ModifierType{EModifierType::Add};
+		UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category="Attribute", meta = (Categories="Attribute", EditConditionHides,
+			EditCondition = "ValueType == EGMCAttributeModifierType::AMT_Attribute || Op == EModifierType::AddPercentageAttribute || Op == EModifierType::AddPercentageOfAttributeRawValue",
+			DisplayAfter = "ValueType"))
+		FGameplayTag ValueAsAttribute;
+	
+		UPROPERTY(Transient)
+		TWeakObjectPtr<UGMCAbilityEffect> SourceAbilityEffect{nullptr};
 
-	// Metadata tags to be passed with the attribute
-	// Ie: DamageType (Element.Fire, Element.Electric), DamageSource (Source.Player, Source.Boss), etc
-	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem")
-	FGameplayTagContainer MetaTags;
+		UPROPERTY(Transient)
+		bool bRegisterInHistory{false};
+
+		float DeltaTime {1.f};
+
+		double ActionTimer {0.0};
+
+		int ApplicationIndex{0};
+
+		UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem")
+		EModifierType Op{EModifierType::Add};
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem",
+		meta=(DisplayAfter = "ValueType", EditConditionHides, EditCondition = "ValueType == EGMCAttributeModifierType::AMT_Custom"))
+		TSubclassOf<UGMCAttributeModifierCustom_Base> CustomModifierClass{nullptr};
+	
+		// Metadata tags to be passed with the attribute
+		// Ie: DamageType (Element.Fire, Element.Electric), DamageSource (Source.Player, Source.Boss), etc
+		UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem")
+		FGameplayTagContainer MetaTags;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem",
+		meta=(EditCondition = "ValueType == EGMCAttributeModifierType::AMT_Value", EditConditionHides, DisplayAfter = "ValueType"))
+		float ModifierValue{0};
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem",
+		meta=(EditCondition = "(Op == EModifierType::AddScaledBetween || Op == EModifierType::AddClampedBetween) && !XAsAttribute", EditConditionHides
+			, DisplayAfter = "XAsAttribute"))
+		float X {0.f};
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem",
+		meta=(EditCondition = "(Op == EModifierType::AddScaledBetween || Op == EModifierType::AddClampedBetween) && !YAsAttribute", EditConditionHides
+			, DisplayAfter = "YAsAttribute"))
+		float Y {0.f};
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem", DisplayName="X As Attribute", 
+		meta=(EditCondition = "Op == EModifierType::AddScaledBetween || Op == EModifierType::AddClampedBetween", EditConditionHides));
+		bool XAsAttribute{false};
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem", DisplayName="Y As Attribute",
+		meta=(EditCondition = "Op == EModifierType::AddScaledBetween || Op == EModifierType::AddClampedBetween", EditConditionHides));
+		bool YAsAttribute{false};
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem",
+		meta=(EditCondition = "(Op == EModifierType::AddScaledBetween || Op == EModifierType::AddClampedBetween) && XAsAttribute", EditConditionHides,
+			DisplayAfter = "XAsAttribute"))
+		FGameplayTag XAttribute;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem",
+		meta=(EditCondition = "(Op == EModifierType::AddScaledBetween || Op == EModifierType::AddClampedBetween) && YAsAttribute", EditConditionHides,
+			DisplayAfter = "YAsAttribute"))
+		FGameplayTag YAttribute;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem",
+		meta=(EditCondition = "Op == EModifierType::AddPercentageAttributeSum", EditConditionHides, DisplayAfter = "ValueType"))
+		FGameplayTagContainer Attributes;
 	
 };

--- a/Source/GMCAbilitySystem/Public/Attributes/GMCAttributeModifierCustom_Base.h
+++ b/Source/GMCAbilitySystem/Public/Attributes/GMCAttributeModifierCustom_Base.h
@@ -1,0 +1,50 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameplayTagContainer.h"
+#include "GMCAbilitySystem.h"
+#include "UObject/Object.h"
+#include "GMCAttributeModifierCustom_Base.generated.h"
+
+struct FAttribute;
+class UGMCAbilityEffect;
+class UGMC_AbilitySystemComponent;
+/**
+ * @class UGMCAttributeModifierCustom_Base
+ *
+ * @brief Defines a custom calculator for applying modifiers to attributes in a system.
+ *
+ * The UGMCAttributeModifierCustomCalculator class provides the capability to calculate
+ * and apply custom attribute modifications based on user-defined logic. This is particularly
+ * useful in situations where attributes need to be adjusted dynamically based on specific
+ * conditions or custom input.
+ *
+ * It supports plug-and-play functionality for entities that utilize modifiable attributes,
+ * allowing users to define and override custom calculation logic if required.
+ *
+ * This class is expected to serve as a base class or utility for systems where attribute
+ * modifiers do not follow a predefined rule set and need bespoke calculations.
+ *
+ * Features include:
+ * - Extension support for custom logic and behaviors.
+ * - Compatibility with general modifier systems.
+ */
+UCLASS(Blueprintable)
+class GMCABILITYSYSTEM_API UGMCAttributeModifierCustom_Base : public UObject
+{
+	GENERATED_BODY()
+
+	public:
+
+		UFUNCTION(BlueprintImplementableEvent)
+		float K2_Calculate(UGMCAbilityEffect* SourceEffect, FGameplayTag AttributeTag) const;
+
+		//  Designed to be overridden in C++ or Blueprint, this function will be called to calculate the final value of the attribute modifier.
+		// If override in C++, don't call super to avoid calling the Blueprint event and pay the performance cost of the Blueprint call.
+	virtual float Calculate(UGMCAbilityEffect* SourceEffect, const FAttribute* Attribute);
+
+protected:
+	bool CheckValidity(const UGMCAbilityEffect* SourceEffect, const FAttribute* Attribute) const;
+};

--- a/Source/GMCAbilitySystem/Public/Attributes/GMCAttributesData.h
+++ b/Source/GMCAbilitySystem/Public/Attributes/GMCAttributesData.h
@@ -37,6 +37,6 @@ class GMCABILITYSYSTEM_API UGMCAttributesData : public UPrimaryDataAsset{
 	GENERATED_BODY()
 
 public:
-	UPROPERTY(EditDefaultsOnly, Category="AttributeData")
+	UPROPERTY(EditDefaultsOnly, Category="AttributeData", meta=(TitleProperty="{AttributeTag} ({DefaultValue})"))
 	TArray<FAttributeData> AttributeData;
 };

--- a/Source/GMCAbilitySystem/Public/Debug/GameplayDebuggerCategory_GMCAbilitySystem.h
+++ b/Source/GMCAbilitySystem/Public/Debug/GameplayDebuggerCategory_GMCAbilitySystem.h
@@ -25,11 +25,17 @@ protected:
 		// Put all data you want to display here
 		FString ActorName;
 		FString GrantedAbilities;
+		int NBGrantedAbilities;
 		FString ActiveTags;
+		int NBActiveTags;
 		FString Attributes;
+		int NBAttributes;
 		FString ActiveEffects;
+		int NBActiveEffects;
 		FString ActiveEffectData;
+		int NBActiveEffectData;
 		FString ActiveAbilities;
+		int NBActiveAbilities;
         
 		void Serialize(FArchive& Ar);
 	};


### PR DESCRIPTION
* Add UPROPERTY Categories to allow compilation as engine plugin.

* Adding Method CancelAbility, allowing ending an ability without triggering EndAbilityEvent. Internally, FinishEndAbility Method as also been added and ensure logics (see GAS termination of an ability)

* Moving Activation tag requirement check before instantiation of the ability.

* Added pre-check function for ability, allowing to have some basic test and allow to cancel an ability if they fail, Overridable in C++ or in Blueprint.

* Adding Precheck and Cancelling by tag

- Adding PreCheck function allowing to test logic on the start of an ability
- Adding Cancelling ability by tag.

* Added Activity Blocked by ActiveAbility

* Fixing crash in HandleTaskHeartBeat.

* Change behavior for attribute ChangeCallback

- Callback OnAttributeChanged is now also called on SP
- Callback is now also called when the value is affected outside for whatever reason (like by SetAttributeValueByTag)
- Support Replay
- SetAttributeValueByTag now also re-caculate the value.



* Change behavior for attribute ChangeCallback

- Callback OnAttributeChanged is now also called on SP/AP
- Callback is now also called when the value is affected outside for whatever reason (like by SetAttributeValueByTag)
- Support Replay
- SetAttributeValueByTag now also re-caculate the value.



* BL-279 Clean before merge
- Removed Log message
- Removed irrelevant bounding



* BL-279 Bug fixing and improvement for rep notify

* BL-279 Fixing Attribute notification

* BL-279 Adding Byte data type to Set Target for DW GMC Ability

* Improvement for tags, added duration

* BL-232 Progress

* BL-232 Initial work on External Effect/Ability Pending and Tag application

* BL-232 Working state.

* BL-232 Refactor and cleaning, handled now by Instanced Struct

* BL-232 Progress of the day

* Fixing a bug in remove effect.

They are now removing by specifique ID when outer removed, to ensure the list rest coherent client <-> server

* BL-232 Fixing removing effect

* BL-232 bug fixing in effect

* Bug fixing, adding accessor

* BL-232 Fix effect remove itself even is another instance is running

* Added getter

* Fixed name space for SetTargetDataFloat, Fixed EEffectType of GMCAbilityEffect sharing same name than playfab, Fixed wait for input key release with suggestion of Nas

* Stability
- Fixed name space for SetTargetDataFloat,
- Fixed EEffectType of GMCAbilityEffect sharing same name than playfab
- Fixed wait for input key release with suggestion of Nas
- GetAbilityMapData now return a const ref.

For compability, you probably want to add to core redirect those lines :
```
+EnumRedirects=(OldName="/Script/GMCAbilitySystem.EEffectType",NewName="/Script/GMCAbilitySystem.EGMASEffectType")
+EnumRedirects=(OldName="/Script/GMCAbilitySystem.EEffectState",NewName="/Script/GMCAbilitySystem.EGMASEffectState")
```

* Adding possibility for effect to end an active ability

* Changing Ability Blocking way.

They are now internally stored. An Ability store itself what ability it will block, instead of other ability who will block him.

This allow to modify during execution this behavior. For example, you may be want to stop an ability activation only during X time in your ability execution.

* Adding a nicer way to end ability

* BL-225 Grenade 100%

* Fix clang error

* Adding Attribute Dynamic Condition to effect.

* Fix crash when an active effect has been destroyed

* Module upload

* GMC Update

* Addition of levitation actor

* Crash fix

* GMC Fix for starting abilities, Fix for stamina,
Fix for crash,
Adding speed for orb,
Adding plugin for metahuman hairs.

* Update for log

* Fix for GetActiveEffect ?

* Typo fix

* Removing unecessary log

* Beginnings of general queue implementation

* Further work on bound queues.

* Convert abilities over to using the new bound operations queue.

* Refactor to generalize ability queue processing

* Convert effects to bound queue

* Refactor and cleanup

* A little more refactoring

* Support server-auth effects queued via GMC moves.

Note that this requires adding an SV_PreRemoteMoveExecution to your movement component, and calling into GMAS's PreRemoteMove call in that.

* Ensure that Queue-via-GMC effects work in standalone as well.

* Queue rework and cleanup finished!

* Last few tweaks to the queue setup.

* Further queue refactor and cleanup.

New queue types (ClientAuth, PredictedQueued) added.

* Add effect handles, so that PredictedQueued works right.

* Small cleanup on effect handle expiry.

* Correct desync for server-auth queue.

* Fix crash BL-SERVER-B

* Ensure we don't use the same ID if queuing two server-auth things in the same frame.

* Fix for Reznok's two-effects-in-one-frame issue.

* Correct issue with 2+ PredictedQueued operations in one tick, or 3+ ServerAuth queued.

* BL-453 Adding application must have tag.

* Fix for server compile

* BL-453 - Fixing AbilityData unset from ability instanciation

* Add Todo.

* - Allowing Predicted effect in Ancilary tick.

* [TO TEST] Moving tick of Actives Effect from Ancilarity to Predicted. Should fix the chain rollback with attribute

* Fixing Crash

* Re-added BL-453 Commit : fix for AbilitytData input activation tag missing from ability instanciation

* Fixing crash in ability task data

* Added EnsureMsfgIf to easier catch miss effect for users. TODO: Add effect tag.

* BL-527 : Fixing nested tag removal in active tag. Issue reported as #98 in Reznok branch (https://github.com/reznok/GMCAbilitySystem/issues/98)

--------------------------------------------

Issue was GetActiveEffectByTag() was looking also for depth in tag hierarchy. Fixed by adding an optional argument (bMatchExact), this argument has been set by default to true, and can mess with project who are calling this function if they are excepting in depht.

Not ideal for retrocompability, but i prefere to enforce a good practice over the time.

* Fixing issue, fix crash on revive, adding

* Add CancelAbilityOnEnd to effects, allowing to stop abilities when the effect End.

* Fixing : Ability blocked by tag doesn't respect hierarchy.

e.g :
Before -> Ability.Item as blocked tag would not block Ability.Item.Use, Ability.Item.Consume but only Ability.Item Now -> Ability.Item as blocked tag would block Ability.Item.Use, Ability.Item.Consume and Ability.Item

* Adding short wrapper of out ability effect, for c++ convenience.

* Adding Remove ability by tag

* Unreachable attempt to catch. Try to understand why, how, etc etc.

* Adding Starting effect and Ending effect event for blueprint.

* Virtualised Start Effect.

* Fixing bad class accessibility

* Fix log spamming (thank me later blue)

* Add better debug message for miss queue prediction of an effect (now display the list of concerned effect)

* Display selected actor's GMAS data in debugger (#103)

* Display selected actor's GMAS data in debugger

* Add methods to add/remove starting effects

* Server auth events 5.5 (#104)

Server Auth Events! They're like server auth effects, but for events!


* fix: merge conflict goofs

* Remove unnecessary header includes

* Keep StructUtils depdendency for older version support

* Fixing missing category specifier.

* Fixing version compability with 5.4 and 5.5 for instanced struct

* - Fix for linux compile on GMC

* Fixing crash in GMC Acknowledgments.

* Fixing crash in GetAllAttributes. ---

We taking copy of bound and unbound attribute struct, but for that we was using a for loop, storing the reference of the for ranged based iterator, instead of the element itself, resulting in UB once the stack was clear. The auto-inlined by the MVSC hidded the issue (i guess ?).

* - Added timeout event on task to allow user to react to it
- Cleanup code for engine and linux compilation

* ** Input Handling Update **
- `ETriggerEvent`: Changed trigger event from `Started` to `Completed` for `AbilityInputAction` binding.
- Input magnitude check: Adjusted condition to correctly detect magnitude with `!ActionValue.GetMagnitude()`.



* **Added**
- `KismetSystemLibrary` include in `WaitForInputKeyPress.cpp` for expanded functionality.

**Updated**
- Changed input trigger event from `ETriggerEvent::Completed` to `ETriggerEvent::Started` in `WaitForInputKeyPress` task for immediate keypress detection.



* - `Rename` method `CancelAbilities` to `CancelConflictingAbilities` for clarity.
- `Enhance` documentation for `CancelConflictingAbilities` to explain its functionality, including tag-based and query-based cancellation checks.



* **GMCAbilityComponent**
- `QueueAbility`: Added `bPreventConcurrentActivation` parameter to prevent concurrent activation of the same ability.
- Implemented local checks in `QueueAbility` to reduce server load and handle ability concurrency locally.
- Updated comments and function documentation for enhanced clarity.



* **Code Cleanup**
- `GMCAbilityComponent.cpp`: Removed trailing whitespace to improve code formatting.



* **Refactored Attribute Processing System**
- Introduced `ProcessPendingModifiers` and `AddModifier` functions for centralized modifier handling in `GMCAttributes`.
- Removed redundant modifier fields (`AdditiveModifier`, `MultiplyModifier`, `DivisionModifier`) in `GMCAttributes`.
- Added `ProcessAttributes` and `PurgeModifierHistory` to `GMCAbilityComponent` for improved attribute management.
- Reworked `ApplyAbilityEffectModifier` to use streamlined attribute processing.
- Introduced attribute-related unit tests (`FAttributeUnitTest.cpp`) for validating modifier application logic.
- Updated `GMCAbilitySystem.Build.cs` to add automation dependencies for testing.

** Attribute Refactor**
- Attribute over time work now based on delta time, each tick, instead of period.
- Attribute will now respect network prediction
- Modifier have now different priority (The phase, The priority and the Operator define the order), they can be set by the user at will.
- Order of Modifier operation is now deterministic
- List of Modifier for attribute :
 - Percent (Percent of the Actual value)
 - Addition (Addition of the current value)
 - Set To base (Reset the value to the base)
 - Percent On Base Value (Apply a percentage from base value to the current value)
 - Set to Value (Direct set to a value)
- Overflow of clamp is now properly handled, including for the replay, and negate at end.
- You can now set a modifier to have as value an attribute instead of a value Usefull for cross operations between attribute.
- Todo : Ability to set dynamically by the code the base value of an attribute at initialisation
- Todo : link back with effect system and event.

* **Refactored Modifier History System**
- Introduced `FModifierHistory` for cleaner separation of bound and unbound modifiers.
- Implemented `AddMoveHistory`, `CleanMoveHistory`, and `ExtractFromMoveHistory` methods for better modifier handling.
- Updated `ProcessPendingModifiers` to directly work with the new history structure.
- Replaced `PurgeModifierHistory` and obsolete functionality in `GMCAbilityComponent`.
- Enhanced test suite in `FAttributeUnitTest.cpp` to validate new modifier operations and interactions.
- Improved code maintainability and fixed edge cases related to modifier history management.
- Large Optimisation of the memory used by AttributeHistory (0.75mb -> 0.33mb on 50k test).
- Large Optimisation of performances for move history
- Split bound and unbound queue for attribute history, added the concept of agglomeration for attribute of the same action timer
- Writing more than 100 units test to ensure attribute constitancy.

* **Refactored Attribute Modifier System**
- Updated `ProcessPendingModifiers` to return a boolean indicating attribute modification status.
- Added logic to broadcast changes for unbound attributes when modified.
- Improved `AttributeDynamicCondition` handling in `PeriodTick` for conditional modifier application.
- Removed unused/obsolete code for cleaner implementation.

* Fixing typo in comment

* **Introduced Custom Modifier System**
- Added `UGMCAttributeModifierCustom_Base` class for modular and extensible attribute calculations.
- Implemented `UGMCModifierCustom_Exponent` with four exponent calculation types (`Mapping`, `Easing`, `Custom Power`, `Saturated`).
- Updated `ProcessPendingModifiers` to support custom modifier logic via `CustomModifierClass`.
- Enhanced `UGMCAbilityEffect` with `ProcessCustomModifier` function and caching for custom modifier instances.
- Improved input validation and error logging for attribute modifiers.
- Updated `GMCAttributes` to handle conditional and dynamic calculators efficiently.

* **Refactored Effect Application and State Management**
- Adjusted `HeartbeatMaxInterval` to 1.5f for improved network resilience.
- Introduced `EGMCEffectAnswerState` enum to handle effect prediction and confirmation states (`Pending`, `Timeout`, `Validated`).
- Enhanced effect lifecycle management with `DeclareEffect` and auto-removal logic during ability end.
- Improved effect application logic, including new `ApplyAbilityEffectSafe` and `ApplyAbilityEffectShort` overloads for optional handling ability.
- Added `GetActiveEffectByHandle` and `RemoveActiveAbilityEffectByHandle` methods to enhance effect access and removal.
- Updated effect logging and validation for better debugging and readability.

* **Enhanced Debugger and Metadata Usage, Attribute Refactor Improvements**
- Added detailed client-server consistency checks and metadata enhancements to gameplay debugger categories.
- Enhanced metadata (`TitleProperty`, `AdvancedDisplay`, `EditCondition`, `DisplayAfter`) for attributes, effects, and abilities for better editor usability.
- Improved string formatting for `ToString` methods across abilities, attributes, and effects for cleaner debug logs.
- Addressed `GMCAbilityEffect` property state coherence and added validation logic in `PostEditChangeProperty`.
- Updated numerical metadata representation in attribute clamp and ability map for enhanced clarity.
- Optimized memory usage and performance in modifier history and active effect systems.
- Enhanced debugger display to show numerical summaries for attributes, effects, and abilities.

* - new attribute system
- gunflare fix
- multiple helicopter extraction



* Remove FORCEINLINE from AddModifier in GMCAttributes.h



* Remove unused ToolMenusEditor include from GMCAttributes.cpp



* - Changing the way attribute operations work with an accumulative stack, and a temporal modifier history.
- BaseValue has been renamed InitialValue
- Stack has been renamed RawValue
- Value now refere as RawValue + Sum of TemporalModifier
- Multiple operator has been added Add, AddPercentageBaseValue, AddPercentageAttribute, AddPercentageMaxClamp, AddPercentageMinClamp, AddPercentageAttributeSum, AddScaledBetween, AddClampedBetween, AddPercentageMissing.
- BlockedByOtherAbility has been added to ability to allow to define from an ability, what it block outside.
- GetAttributeRawValueByTag has been added.
- You can now define attribute initial value at initialisation of the attribute (blueprint or c++).
- Improved debugger with detection of incoherency on application, and better value/clarity
- Improved QoL for creation of effect/attributes.
- Better readibility for attribute map, and ability map.

* - Fixed Periodic effect, they now work properly with replay and negate.

* Fixing Effect type not available in blueprint.

* fix: enhance error logging for unknown modifier types in FAttribute

* feat: add new modifier type "AddPercentageOfAttributeRawValue"

- Introduced support for the new modifier type `AddPercentageOfAttributeRawValue` in `GMCAttributeModifier`.
- Updated logic to handle raw attribute values without temporal modifiers.
- Improved metadata validation and configuration for added modifier type.

* refactor: optimize active ability effect removal logic

- Replaced iteration with `FilterByPredicate` to extract effects for removal in `GMCAbilityComponent`.
- Improved code readability and performance by separating filtered effects before processing.
- Simplified logic for removing predicted effects during movement or ancillary ticks.

* refactor: simplify active effect removal logic in GMCAbilityComponent

- Replaced `FilterByPredicate` with an explicit loop and conditional checks for clarity.
- Improved readability and maintainability by iterating over `Ids` directly to collect effects for removal.

* Higher task heartbeat value.

---------